### PR TITLE
Bump commons-fileupload from 1.3.1 to 1.3.3 in /image-recognition

### DIFF
--- a/image-recognition/pom.xml
+++ b/image-recognition/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.1</version>
+			<version>1.3.3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps commons-fileupload from 1.3.1 to 1.3.3.

Signed-off-by: dependabot[bot] <support@github.com>